### PR TITLE
Save computed y-values in linearization

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -1,0 +1,36 @@
+# GitHub workflow to enable continuous integratoin
+name: Continuous Integration
+
+# This workflow is triggered on pushes and pull requests to the repository.
+on: 
+  push:
+    branches: '*'
+  pull_request: 
+    branches: 'master'
+
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, macos-10.15 ]
+        cxx: [ g++-9, clang++ ]
+        build_type: [ Debug, Release ]
+
+    steps:
+    - name: which CXX
+      run: |
+        which ${{matrix.cxx}} 
+        ${{matrix.cxx}} --version
+    - uses: actions/checkout@v2
+    - name: mkdir bin
+      run: mkdir bin 
+    - name: cmake
+      run: cmake -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} ..  
+      working-directory: ./bin
+    - name: make
+      run: make -j2
+      working-directory: ./bin
+    - name: ctest
+      run: ctest -j2
+      working-directory: ./bin

--- a/src/twig.hpp
+++ b/src/twig.hpp
@@ -6,7 +6,6 @@
 #include <numeric>
 #include <vector>
 #include <iostream>
-#include <memory>
   
 namespace njoy {
 namespace twig {

--- a/src/twig.hpp
+++ b/src/twig.hpp
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <vector>
 #include <iostream>
+#include <memory>
   
 namespace njoy {
 namespace twig {

--- a/src/twig/linearize/Callable.hpp
+++ b/src/twig/linearize/Callable.hpp
@@ -17,9 +17,6 @@ Callable( Xstack& xStack, Ystack& yStack ) :
   yStack_( &yStack )
 {}
 
-  void xStack( Xstack& stack ){ this->xStack_ = &stack; }
-  void yStack( Ystack& stack ){ this->yStack_ = &stack; }
-
   template< typename... Args >
   void operator()( Args&&... args ){
     this->grid( std::forward<Args>(args)... );  

--- a/src/twig/linearize/Callable.hpp
+++ b/src/twig/linearize/Callable.hpp
@@ -1,8 +1,13 @@
-template< typename Xstack, typename Ydata >
+template< typename Xstack, typename Ystack >
 class Callable {
   using Xdata = typename Xstack::value_type;
+  using Ydata = typename Ystack::value_type;
 
-  Xstack* stack;
+public:
+  Xstack* xStack_;
+  Ystack* yStack_;
+  // std::unique_ptr< Xstack > xStack_;
+  // std::unique_ptr< Ystack > yStack_;
   std::vector< Xdata > xBuffer{};
   std::vector< Ydata > yBuffer{};
 
@@ -10,8 +15,13 @@ class Callable {
   #include "twig/linearize/Callable/src/grid.hpp"
 
 public:
-  Callable( Xstack& xStack ) : stack( &xStack ){}
-  void xStack( Xstack& stack ){ this->stack = &stack; }
+Callable( Xstack& xStack, Ystack& yStack ) : 
+  xStack_( &xStack ),
+  yStack_( &yStack )
+{}
+
+  void xStack( Xstack& stack ){ this->xStack_ = &stack; }
+  void yStack( Ystack& stack ){ this->yStack_ = &stack; }
 
   template< typename... Args >
   void operator()( Args&&... args ){
@@ -19,7 +29,7 @@ public:
   }
 };
 
-template< typename Ydata, typename Xstack >
-auto callable( Xstack& stack ){
-  return Callable< Xstack, Ydata >( stack );
+template< typename Ystack, typename Xstack >
+auto callable( Xstack& xStack, Ystack& yStack ){
+  return Callable( xStack, yStack );
 }

--- a/src/twig/linearize/Callable.hpp
+++ b/src/twig/linearize/Callable.hpp
@@ -6,8 +6,6 @@ class Callable {
 public:
   Xstack* xStack_;
   Ystack* yStack_;
-  // std::unique_ptr< Xstack > xStack_;
-  // std::unique_ptr< Ystack > yStack_;
   std::vector< Xdata > xBuffer{};
   std::vector< Ydata > yBuffer{};
 

--- a/src/twig/linearize/Callable.hpp
+++ b/src/twig/linearize/Callable.hpp
@@ -3,7 +3,6 @@ class Callable {
   using Xdata = typename Xstack::value_type;
   using Ydata = typename Ystack::value_type;
 
-public:
   Xstack* xStack_;
   Ystack* yStack_;
   std::vector< Xdata > xBuffer{};

--- a/src/twig/linearize/Callable/src/bin.hpp
+++ b/src/twig/linearize/Callable/src/bin.hpp
@@ -15,9 +15,11 @@ void bin( Xdata xLeft, Xdata xRight,
         x[left], x[right],
         y[left], y[right] ) ){
 
-      this->stack->push_back( x[left] );
+      this->xStack_->push_back( x[left] );
+      this->yStack_->push_back( y[left] );
       if ( not this->xBuffer.size() ){ 
-        this->stack->push_back( x[right] );
+        // this->xStack_->push_back( x[right] );
+        // this->yStack_->push_back( y[right] );
         break; 
       }
 

--- a/src/twig/linearize/Callable/src/bin.hpp
+++ b/src/twig/linearize/Callable/src/bin.hpp
@@ -18,8 +18,8 @@ void bin( Xdata xLeft, Xdata xRight,
       this->xStack_->push_back( x[left] );
       this->yStack_->push_back( y[left] );
       if ( not this->xBuffer.size() ){ 
-        // this->xStack_->push_back( x[right] );
-        // this->yStack_->push_back( y[right] );
+        this->xStack_->push_back( x[right] );
+        this->yStack_->push_back( y[right] );
         break; 
       }
 

--- a/src/twig/linearize/Callable/src/bin.hpp
+++ b/src/twig/linearize/Callable/src/bin.hpp
@@ -18,8 +18,6 @@ void bin( Xdata xLeft, Xdata xRight,
       this->xStack_->push_back( x[left] );
       this->yStack_->push_back( y[left] );
       if ( not this->xBuffer.size() ){ 
-        this->xStack_->push_back( x[right] );
-        this->yStack_->push_back( y[right] );
         break; 
       }
 

--- a/src/twig/linearize/Callable/src/grid.hpp
+++ b/src/twig/linearize/Callable/src/grid.hpp
@@ -10,7 +10,7 @@ template< typename ForwardIterator,
           typename Convergence,
           typename Midpoint >
 void grid( ForwardIterator& first,
-           ForwardIterator last,
+           ForwardIterator& last,
            Functor&& functor,
            Convergence&& criterion,
            Midpoint&& midpoint ){
@@ -29,4 +29,6 @@ void grid( ForwardIterator& first,
     xLeft = xRight;
     yLeft = yRight;
   }
+  this->xStack_->push_back( xRight );
+  this->yStack_->push_back( yRight );
 }

--- a/src/twig/linearize/Callable/src/grid.hpp
+++ b/src/twig/linearize/Callable/src/grid.hpp
@@ -6,8 +6,8 @@
  * x-range argument.
  **/
 template< typename ForwardIterator,
-    typename Functor,
-    typename Convergence,
+          typename Functor,
+          typename Convergence,
           typename Midpoint >
 void grid( ForwardIterator& first,
            ForwardIterator last,
@@ -16,9 +16,12 @@ void grid( ForwardIterator& first,
            Midpoint&& midpoint ){
   auto xLeft = *first; ++first;
   auto yLeft = functor( xLeft );
+
+  decltype( xLeft ) xRight;
+  decltype( yLeft ) yRight;
   while ( first != last ){
-    auto xRight = *first; ++first;
-    auto yRight = functor( xRight );
+    xRight = *first; ++first;
+    yRight = functor( xRight );
     this->bin( xLeft, xRight, yLeft, yRight,
                std::forward<Functor>(functor),
                std::forward<Convergence>(criterion),
@@ -26,4 +29,6 @@ void grid( ForwardIterator& first,
     xLeft = xRight;
     yLeft = yRight;
   }
+  this->xStack_->push_back( xRight );
+  this->yStack_->push_back( yRight );
 }

--- a/src/twig/linearize/Callable/src/grid.hpp
+++ b/src/twig/linearize/Callable/src/grid.hpp
@@ -29,6 +29,4 @@ void grid( ForwardIterator& first,
     xLeft = xRight;
     yLeft = yRight;
   }
-  this->xStack_->push_back( xRight );
-  this->yStack_->push_back( yRight );
 }

--- a/src/twig/linearize/Callable/src/grid.hpp
+++ b/src/twig/linearize/Callable/src/grid.hpp
@@ -10,7 +10,7 @@ template< typename ForwardIterator,
           typename Convergence,
           typename Midpoint >
 void grid( ForwardIterator& first,
-           ForwardIterator& last,
+           ForwardIterator last,
            Functor&& functor,
            Convergence&& criterion,
            Midpoint&& midpoint ){

--- a/src/twig/linearize/Callable/src/grid.hpp
+++ b/src/twig/linearize/Callable/src/grid.hpp
@@ -17,8 +17,8 @@ void grid( ForwardIterator& first,
   auto xLeft = *first; ++first;
   auto yLeft = functor( xLeft );
 
-  decltype( xLeft ) xRight;
-  decltype( yLeft ) yRight;
+  auto xRight = xLeft;
+  auto yRight = yLeft;
   while ( first != last ){
     xRight = *first; ++first;
     yRight = functor( xRight );

--- a/src/twig/linearize/Callable/test/Callable.test.cpp
+++ b/src/twig/linearize/Callable/test/Callable.test.cpp
@@ -8,13 +8,6 @@
 
 using namespace njoy::twig;
 
-void printv( const std::vector< double >& v, std::string name ){
-  std::cout << name << ": ";
-  for( auto x: v ){
-    std::cout << x << ", ";
-  }
-  std::cout << std::endl;
-}
 SCENARIO("Broken stick implementation"){
   std::vector< double > xInstance;
   std::vector< double > yInstance;
@@ -50,6 +43,7 @@ SCENARIO("Broken stick implementation"){
   }
   
   auto length = xInstance.size();
+  CHECK( 1793 == length );
   for (size_t i{ 0 }; i < length; ++i) {
     CHECK( yInstance[ i ] == functor( xInstance[ i ] ) );
   }

--- a/src/twig/linearize/Callable/test/Callable.test.cpp
+++ b/src/twig/linearize/Callable/test/Callable.test.cpp
@@ -44,6 +44,7 @@ SCENARIO("Broken stick implementation"){
   
   auto length = xInstance.size();
   CHECK( 1793 == length );
+  CHECK( 1793 == yInstance.size() );
   for (size_t i{ 0 }; i < length; ++i) {
     CHECK( yInstance[ i ] == functor( xInstance[ i ] ) );
   }

--- a/src/twig/linearize/Callable/test/Callable.test.cpp
+++ b/src/twig/linearize/Callable/test/Callable.test.cpp
@@ -49,18 +49,7 @@ SCENARIO("Broken stick implementation"){
                         [&]( auto& arg ){ return arg == x; } ) );
   }
   
-  auto iterator = xInstance.begin();
-
-  auto left = [&iterator](){ return iterator[0]; };
-  auto right = [&iterator](){ return iterator[1]; };
-
-  auto x = []( auto value ){ return value; };
-  auto y = [&]( auto value ){ return functor( value ); };
-
-
   auto length = xInstance.size();
-  std::cout << "xlength: " << xInstance.size() << std::endl;
-  std::cout << "ylength: " << yInstance.size() << std::endl;
   for (size_t i{ 0 }; i < length; ++i) {
     CHECK( yInstance[ i ] == functor( xInstance[ i ] ) );
   }

--- a/src/twig/linearize/Callable/test/Callable.test.cpp
+++ b/src/twig/linearize/Callable/test/Callable.test.cpp
@@ -8,9 +8,18 @@
 
 using namespace njoy::twig;
 
+void printv( const std::vector< double >& v, std::string name ){
+  std::cout << name << ": ";
+  for( auto x: v ){
+    std::cout << x << ", ";
+  }
+  std::cout << std::endl;
+}
 SCENARIO("Broken stick implementation"){
-  std::vector< double > instance;
-  instance.reserve(100);
+  std::vector< double > xInstance;
+  std::vector< double > yInstance;
+  xInstance.reserve(100);
+  yInstance.reserve(100);
 
   std::vector< double > xgrid{ 1.0, 5.0, 13.0, 29.0 };
 
@@ -28,7 +37,7 @@ SCENARIO("Broken stick implementation"){
     return 0.5 * ( std::get<0>(x) + std::get<1>(x) );
   };
 
-  auto linearization = linearize::callable< double >( instance );
+  auto linearization = linearize::callable( xInstance, yInstance );
   auto first = xgrid.begin();
   auto last = xgrid.end();
   linearization( first, last, functor, criterion, midpoint );
@@ -36,11 +45,11 @@ SCENARIO("Broken stick implementation"){
 
   // Make sure all the original x values are in the linearized x
   for( double& x : xgrid ){
-    CHECK( std::any_of( instance.begin(), instance.end(), 
+    CHECK( std::any_of( xInstance.begin(), xInstance.end(), 
                         [&]( auto& arg ){ return arg == x; } ) );
   }
   
-  auto iterator = instance.begin();
+  auto iterator = xInstance.begin();
 
   auto left = [&iterator](){ return iterator[0]; };
   auto right = [&iterator](){ return iterator[1]; };
@@ -48,13 +57,11 @@ SCENARIO("Broken stick implementation"){
   auto x = []( auto value ){ return value; };
   auto y = [&]( auto value ){ return functor( value ); };
 
-  while ( iterator != std::prev( instance.end() ) ){
-    const auto midpoint = 0.5 * ( x( left() ) + x( right() ) );
-    const auto trial = 0.5 * ( y( left() ) + y( right() ) );
-    const auto reference = y( midpoint );
-    CHECK( criterion( trial, reference,
-                       x( left() ), x( right() ),
-                       y( left() ), y( right() ) ) );
-    ++iterator;
+
+  auto length = xInstance.size();
+  std::cout << "xlength: " << xInstance.size() << std::endl;
+  std::cout << "ylength: " << yInstance.size() << std::endl;
+  for (size_t i{ 0 }; i < length; ++i) {
+    CHECK( yInstance[ i ] == functor( xInstance[ i ] ) );
   }
 }  


### PR DESCRIPTION
@whaeck and I had a conversation where I mentioned that the linearization doesn't preserve the computed y-values—but it does preserve the x-grid, which can then be used to re-compute the y-values. This could be *very* costly, particularly when we would use this capability to linearize resonances. Since calculating a cross section from resonance parameters is expensive, calculating it twice would be (obviously) twice as expensive. 

This pull request stores the computed y-values in a manner similar to how the x-values are stored. It seems like this was unintentionally left out, but I can't guarantee the intent of the original author (@apmccartney).